### PR TITLE
Adicionar serviços LangSharp e remover configuração SDK

### DIFF
--- a/src/LangSharp/Registrations/ServiceRegistrar.cs
+++ b/src/LangSharp/Registrations/ServiceRegistrar.cs
@@ -25,7 +25,6 @@ namespace LangSharp.Registrations
             services.TryAddScoped<ILangSharpService, LangSharpService>();
             services.TryAddScoped<IPythonService, PythonService>();
 
-
             //Add SDK Config
             services.TryAddSingleton(configuration);
 


### PR DESCRIPTION
Modificado o registro de serviços para incluir `ILangSharpService` e `IPythonService` no contêiner de serviços. A linha que adicionava a configuração do SDK foi removida, indicando uma possível simplificação na gestão de serviços.