### PR TITLE
Adicionar coleta de cobertura de código nos testes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
       run: dotnet build --no-restore
       
     - name: Test
-      run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory TestResults
-
-    - name: Extract coverage value
       run: |
-        COVERAGE_FILE=$(find TestResults -name "coverage.cobertura.xml" | head -n 1)
-        COVERAGE_VALUE=$(grep -oP '(?<=line-rate=")[0-9.]+(?=")' "$COVERAGE_FILE")
-        echo "Code Coverage: $COVERAGE_VALUE" >> $GITHUB_STEP_SUMMARY
+        dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory TestResults | tee test-output.txt
+
+    - name: Extract test summary
+      run: |
+        TEST_SUMMARY=$(grep -oP 'Resumo do teste:.*' test-output.txt)
+        echo "$TEST_SUMMARY" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,9 @@ jobs:
       
     - name: Test
       run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage"
+
+    - name: Extract coverage value
+      run: |
+        COVERAGE_FILE=$(find TestResults -name "coverage.cobertura.xml" | head -n 1)
+        COVERAGE_VALUE=$(grep -oP '(?<=line-rate=")[0-9.]+(?=")' "$COVERAGE_FILE")
+        echo "Code Coverage: $COVERAGE_VALUE" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
       run: dotnet build --no-restore
       
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet build --no-restore
       
     - name: Test
-      run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage"
+      run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory TestResults
 
     - name: Extract coverage value
       run: |


### PR DESCRIPTION
Atualiza o comando `dotnet test` para incluir a opção `--collect:"XPlat Code Coverage"`, permitindo a coleta de informações sobre a cobertura de código durante a execução dos testes. Isso ajuda a avaliar a qualidade do código testado.