### PR TITLE
Atualiza instruções e lógica de caminhos para Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To run the LangSharp SDK in a Docker container, ensure Python and required depen
 
 ### Linux
 
-Install Python 3.11.7 and development headers:
+Install Python 3.11.x:
 
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
@@ -106,9 +106,8 @@ WORKDIR /app
 RUN apt update && \
     apt install -y \
     python3.11 \
-    python3.11-dev \
     python3-pip \
-    libpython3.11-dev \
+    python3-venv \
     && rm -rf /var/lib/apt/lists/*
 ```
 

--- a/README.md
+++ b/README.md
@@ -111,21 +111,6 @@ RUN apt update && \
     && rm -rf /var/lib/apt/lists/*
 ```
 
-### Windows
-
-Copy the Python package from the global NuGet cache into the publish folder:
-
-```dockerfile
-FROM build AS publish
-ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./LangSharp.Examples.AspNetCore.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
-RUN mkdir -p /app/publish/root/.nuget/packages && \
-    cp -r /root/.nuget/packages/python /app/publish/root/.nuget/packages/
-```
-
-> ?? Note: This is required because the default NuGet global packages path (`/root/.nuget/packages`) is not available at runtime. Copying it ensures that Python.NET can locate the Python package during execution.
-
-
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for more details.

--- a/src/LangSharp/Core/Factorys/PathServiceFactory.cs
+++ b/src/LangSharp/Core/Factorys/PathServiceFactory.cs
@@ -1,0 +1,20 @@
+﻿using LangSharp.Core.Interfaces.Services;
+using LangSharp.Core.Services;
+using System.Runtime.InteropServices;
+
+namespace LangSharp.Core.Factorys
+{
+    public class PathServiceFactory
+    {
+        public static IPathService CreateForCurrentEnvironment()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return new PathService();
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return new PathLinuxService();
+
+            throw new NotSupportedException("The current platform is not supported.");
+        }
+    }
+}

--- a/src/LangSharp/Core/Infrastructure/PythonRuntime.cs
+++ b/src/LangSharp/Core/Infrastructure/PythonRuntime.cs
@@ -22,5 +22,29 @@ namespace LangSharp.Core.Infrastructure
         {
             return Py.Import(moduleName);
         }
+
+        public int ExecuteProcess(string fileName, string arguments, out string output, out string error)
+        {
+            var startInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = System.Diagnostics.Process.Start(startInfo);
+
+            if (process == null)
+                throw new InvalidOperationException("Could not start the process.");
+
+            output = process.StandardOutput.ReadToEnd();
+            error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            return process.ExitCode;
+        }
     }
 }

--- a/src/LangSharp/Core/Interfaces/Infrastructure/IPythonRuntime.cs
+++ b/src/LangSharp/Core/Interfaces/Infrastructure/IPythonRuntime.cs
@@ -8,5 +8,6 @@ namespace LangSharp.Core.Interfaces.Infrastructure
         void Initialize();
         IDisposable AcquireGIL();
         PyObject Import(string moduleName);
+        int ExecuteProcess(string fileName, string arguments, out string output, out string error);
     }
 }

--- a/src/LangSharp/Core/Interfaces/Services/IEnvironmentService.cs
+++ b/src/LangSharp/Core/Interfaces/Services/IEnvironmentService.cs
@@ -3,6 +3,6 @@
     public interface IEnvironmentService
     {
         void ConfigurePythonEnvironment(string pythonHome, string sitePackagesPath, string pythonDllPath);
-        void ConfigurePythonEnvironment(string pythonHome, string sitePackagesPath);
+        void ConfigurePythonVirtualEnvironment(string sitePackagesPath, bool isVenv);
     }
 }

--- a/src/LangSharp/Core/Interfaces/Services/IPathService.cs
+++ b/src/LangSharp/Core/Interfaces/Services/IPathService.cs
@@ -10,7 +10,7 @@
         string GetVenvPath();
         string GetScriptsPath(string scriptName);
         string GetScriptsPathByPackageDir(string scriptName);
-        string GetSitePackagesPathFromPythonHome();
+        string GetSitePackagesPath();
         string GetDirectoryName(string? path);
     }
 }

--- a/src/LangSharp/Core/Services/EnvironmentService.cs
+++ b/src/LangSharp/Core/Services/EnvironmentService.cs
@@ -9,13 +9,26 @@ namespace LangSharp.Core.Services
             Environment.SetEnvironmentVariable("PYTHONNET_PYDLL", pythonDllPath, EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("PYTHONHOME", pythonHome, EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("PYTHONPATH", sitePackagesPath, EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("LANGSHARP_IS_VENV", false.ToString(), EnvironmentVariableTarget.Process);
         }
 
         public void ConfigurePythonEnvironment(string pythonHome, string sitePackagesPath)
         {
             Environment.SetEnvironmentVariable("PYTHONHOME", pythonHome, EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("PYTHONPATH", sitePackagesPath, EnvironmentVariableTarget.Process);
+        }
 
+
+        public void ConfigurePythonVirtualEnvironment(string sitePackagesPath, bool isVenv)
+        {
+            var currentPythonPath = Environment.GetEnvironmentVariable("PYTHONPATH", EnvironmentVariableTarget.Process);
+            
+            string newPythonPath = string.IsNullOrEmpty(currentPythonPath)
+                ? sitePackagesPath
+                : $"{sitePackagesPath};{currentPythonPath}";
+
+            Environment.SetEnvironmentVariable("PYTHONPATH", newPythonPath, EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("LANGSHARP_IS_VENV", isVenv.ToString(), EnvironmentVariableTarget.Process);
         }
     }
 }

--- a/src/LangSharp/Core/Services/PathLinuxService.cs
+++ b/src/LangSharp/Core/Services/PathLinuxService.cs
@@ -1,110 +1,88 @@
 ﻿using LangSharp.Core.Interfaces.Services;
 using LangSharp.Utils;
-using NuGet.Configuration;
 
 namespace LangSharp.Core.Services
 {
     public class PathLinuxService : IPathService
     {
+        private const string PythonVersion = "3.11";
+        private const string PythonDll = $"libpython{PythonVersion}.so.1.0";
+        private const string PythonBin = $"python{PythonVersion}";
+        private const string LibDir = "lib";
+        private const string SitePackages = "site-packages";
+        private const string VenvDir = "venv";
+        private const string NugetRoot = "root";
+        private const string NugetFolder = ".nuget";
+        private const string NugetPackages = "packages";
+        private const string ScriptsFolder = "Scripts";
+        private const string LangSharpFolder = "langsharp";
+
         public string GetNuggetPath()
         {
-            var isDocker = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER", EnvironmentVariableTarget.Process);
-
-            if (!string.IsNullOrEmpty(isDocker) && bool.Parse(isDocker))
-            {
-                return Path.Combine(Path.DirectorySeparatorChar.ToString(), Environment.CurrentDirectory, "root", ".nuget", "packages");
-            }
-
-            ISettings settings = Settings.LoadDefaultSettings(null);
-            var nugetPath = SettingsUtility.GetGlobalPackagesFolder(settings);
-
-            return nugetPath;
+            return Path.Combine(Path.DirectorySeparatorChar.ToString(), Environment.CurrentDirectory, NugetRoot, NugetFolder, NugetPackages);
         }
+
         public string GetPythonDllPath()
         {
-            var isDocker = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER", EnvironmentVariableTarget.Process);
-
-            if (!string.IsNullOrEmpty(isDocker) && bool.Parse(isDocker))
-            {
-                return Path.Combine(Path.DirectorySeparatorChar.ToString(), "usr", "lib", "x86_64-linux-gnu", "libpython3.11.so.1.0");
-            }
-
-            return Path.Combine(GetPythonPath(), EnvironmentConsts.DllVersionName);
+            return Path.Combine("/usr/lib/x86_64-linux-gnu", PythonDll);
         }
 
         public string GetPythonPath()
         {
-            return Path.Combine(Path.DirectorySeparatorChar.ToString(), "usr");
+            return "/usr";
         }
 
         public string GetPythonVenvPath()
         {
-            return Path.Combine(Path.DirectorySeparatorChar.ToString(), "usr");
+            return GetVenvPath();
         }
 
         public string GetPythonPathExecutable()
         {
             var isVenv = Environment.GetEnvironmentVariable("LANGSHARP_IS_VENV", EnvironmentVariableTarget.Process);
 
-            return !string.IsNullOrEmpty(isVenv) && bool.Parse(isVenv)
-                ? GetPythonPathExecutableForVenv(GetPythonVenvPath())
-                : GetPythonPathExecutableForStandardInstallation(GetPythonPath());
+            return !string.IsNullOrEmpty(isVenv) && bool.TryParse(isVenv, out var venv) && venv
+                ? Path.Combine(GetVenvPath(), "bin", PythonBin)
+                : Path.Combine(GetPythonPath(), "bin", PythonBin);
         }
 
         public string GetScriptsPath(string scriptName)
         {
-            return Path.Combine(AppContext.BaseDirectory, "Scripts", scriptName);
+            return Path.Combine(AppContext.BaseDirectory, ScriptsFolder, scriptName);
         }
 
         public string GetScriptsPathByPackageDir(string scriptName)
         {
             var nuggetPath = GetNuggetPath();
+            var version = EnvironmentConsts.GetLangSharpAssemblyVersion();
 
-            return Path.Combine(
-              Path.Combine(
-                  nuggetPath, "langsharp", EnvironmentConsts.GetLangSharpAssemblyVersion()
-              ),
-              "Scripts", scriptName);
+            return Path.Combine(nuggetPath, LangSharpFolder, version, ScriptsFolder, scriptName);
         }
 
         public string GetSitePackagesPath(string basePath)
         {
-            return Path.Combine(basePath, "lib", "python3.11", "site-packages");
+            return Path.Combine(basePath, LibDir, $"python{PythonVersion}", SitePackages);
         }
 
-        public string GetSitePackagesPathFromPythonHome()
+        public string GetSitePackagesPath()
         {
-            var pythonHome = Environment.GetEnvironmentVariable("PYTHONHOME", EnvironmentVariableTarget.Process);
+            var isVenv = Environment.GetEnvironmentVariable("LANGSHARP_IS_VENV", EnvironmentVariableTarget.Process);
 
-            if (string.IsNullOrEmpty(pythonHome))
-                return string.Empty;
-
-            return GetSitePackagesPath(pythonHome);
+            return !string.IsNullOrEmpty(isVenv) && bool.TryParse(isVenv, out var venv) && venv
+                ? GetSitePackagesPath(GetVenvPath())
+                : Path.Combine(GetPythonPath(), LibDir, $"python{PythonVersion}", SitePackages);
         }
 
         public string GetVenvPath()
         {
             var nuggetPath = GetNuggetPath();
 
-            return Path.Combine(
-                nuggetPath, "python", EnvironmentConsts.PythonVersion,
-                EnvironmentConsts.VirtualEnvironment);
+            return Path.Combine(nuggetPath, "python", PythonVersion, VenvDir);
         }
 
         public string GetDirectoryName(string? path)
         {
             return Path.GetDirectoryName(path) ?? string.Empty;
         }
-
-        private static string GetPythonPathExecutableForVenv(string pythonHome)
-        {
-            return Path.Combine(pythonHome, "bin", "python3.11");
-        }
-
-        private static string GetPythonPathExecutableForStandardInstallation(string pythonHome)
-        {
-            return Path.Combine(pythonHome, "bin", "python3.11");
-        }
-
     }
 }

--- a/src/LangSharp/Core/Services/PathLinuxService.cs
+++ b/src/LangSharp/Core/Services/PathLinuxService.cs
@@ -4,10 +4,17 @@ using NuGet.Configuration;
 
 namespace LangSharp.Core.Services
 {
-    public class PathService : IPathService
+    public class PathLinuxService : IPathService
     {
         public string GetNuggetPath()
         {
+            var isDocker = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER", EnvironmentVariableTarget.Process);
+
+            if (!string.IsNullOrEmpty(isDocker) && bool.Parse(isDocker))
+            {
+                return Path.Combine(Path.DirectorySeparatorChar.ToString(), Environment.CurrentDirectory, "root", ".nuget", "packages");
+            }
+
             ISettings settings = Settings.LoadDefaultSettings(null);
             var nugetPath = SettingsUtility.GetGlobalPackagesFolder(settings);
 
@@ -15,25 +22,24 @@ namespace LangSharp.Core.Services
         }
         public string GetPythonDllPath()
         {
+            var isDocker = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER", EnvironmentVariableTarget.Process);
+
+            if (!string.IsNullOrEmpty(isDocker) && bool.Parse(isDocker))
+            {
+                return Path.Combine(Path.DirectorySeparatorChar.ToString(), "usr", "lib", "x86_64-linux-gnu", "libpython3.11.so.1.0");
+            }
+
             return Path.Combine(GetPythonPath(), EnvironmentConsts.DllVersionName);
         }
 
         public string GetPythonPath()
         {
-            string nugetPath = GetNuggetPath();
-
-            var pythonPath = Path.Combine(nugetPath, "python", EnvironmentConsts.PythonVersion, "tools");
-
-            return pythonPath;
+            return Path.Combine(Path.DirectorySeparatorChar.ToString(), "usr");
         }
 
         public string GetPythonVenvPath()
         {
-            string nugetPath = GetNuggetPath();
-
-            var pythonPath = Path.Combine(nugetPath, "python", EnvironmentConsts.PythonVersion, EnvironmentConsts.VirtualEnvironment);
-
-            return pythonPath;
+            return Path.Combine(Path.DirectorySeparatorChar.ToString(), "usr");
         }
 
         public string GetPythonPathExecutable()
@@ -63,7 +69,7 @@ namespace LangSharp.Core.Services
 
         public string GetSitePackagesPath(string basePath)
         {
-            return Path.Combine(basePath, "Lib", "site-packages");
+            return Path.Combine(basePath, "lib", "python3.11", "site-packages");
         }
 
         public string GetSitePackagesPathFromPythonHome()
@@ -73,11 +79,7 @@ namespace LangSharp.Core.Services
             if (string.IsNullOrEmpty(pythonHome))
                 return string.Empty;
 
-            var isVirtualEnv = Environment.GetEnvironmentVariable("LANGSHARP_IS_VENV", EnvironmentVariableTarget.Process);
-
-            return  !string.IsNullOrEmpty(isVirtualEnv) && bool.Parse(isVirtualEnv)
-                ? Path.Combine(GetPythonVenvPath(), "Lib", "site-packages")
-                : Path.Combine(pythonHome, "Lib");
+            return GetSitePackagesPath(pythonHome);
         }
 
         public string GetVenvPath()
@@ -96,12 +98,12 @@ namespace LangSharp.Core.Services
 
         private static string GetPythonPathExecutableForVenv(string pythonHome)
         {
-            return Path.Combine(pythonHome, "Scripts", "python.exe");
+            return Path.Combine(pythonHome, "bin", "python3.11");
         }
 
         private static string GetPythonPathExecutableForStandardInstallation(string pythonHome)
         {
-            return Path.Combine(pythonHome, "python.exe");
+            return Path.Combine(pythonHome, "bin", "python3.11");
         }
 
     }

--- a/src/LangSharp/Core/Services/PathLinuxService.cs
+++ b/src/LangSharp/Core/Services/PathLinuxService.cs
@@ -10,7 +10,6 @@ namespace LangSharp.Core.Services
         private const string PythonBin = $"python{PythonVersion}";
         private const string LibDir = "lib";
         private const string SitePackages = "site-packages";
-        private const string VenvDir = "venv";
         private const string NugetRoot = "root";
         private const string NugetFolder = ".nuget";
         private const string NugetPackages = "packages";
@@ -77,7 +76,7 @@ namespace LangSharp.Core.Services
         {
             var nuggetPath = GetNuggetPath();
 
-            return Path.Combine(nuggetPath, "python", PythonVersion, VenvDir);
+            return Path.Combine(nuggetPath, "python", EnvironmentConsts.PythonVersion, EnvironmentConsts.VirtualEnvironment);
         }
 
         public string GetDirectoryName(string? path)

--- a/src/LangSharp/Core/Services/PathService.cs
+++ b/src/LangSharp/Core/Services/PathService.cs
@@ -7,13 +7,18 @@ namespace LangSharp.Core.Services
 {
     public class PathService : IPathService
     {
-        public string GetNuggetPath() 
+        public string GetNuggetPath()
         {
             var isDocker = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER", EnvironmentVariableTarget.Process);
 
             if (!string.IsNullOrEmpty(isDocker) && bool.Parse(isDocker) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return Path.Combine(Environment.CurrentDirectory, "root", ".nuget", "packages");
+            }
+
+            if (!string.IsNullOrEmpty(isDocker) && bool.Parse(isDocker) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return Path.Combine(Path.DirectorySeparatorChar.ToString(), Environment.CurrentDirectory, "root", ".nuget", "packages");
             }
 
             ISettings settings = Settings.LoadDefaultSettings(null);
@@ -35,6 +40,9 @@ namespace LangSharp.Core.Services
 
         public string GetPythonPath()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return Path.Combine(Path.DirectorySeparatorChar.ToString(), "usr");
+
             string nugetPath = GetNuggetPath();
 
             var pythonPath = Path.Combine(nugetPath, "python", EnvironmentConsts.PythonVersion, "tools");
@@ -58,7 +66,7 @@ namespace LangSharp.Core.Services
 
         public string GetScriptsPath(string scriptName)
         {
-            return Path.Combine(AppContext.BaseDirectory, "scripts", scriptName);
+            return Path.Combine(AppContext.BaseDirectory, "Scripts", scriptName);
         }
 
         public string GetScriptsPathByPackageDir(string scriptName)
@@ -74,15 +82,23 @@ namespace LangSharp.Core.Services
 
         public string GetSitePackagesPath(string basePath)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return Path.Combine(basePath, "lib", "python3.11", "site-packages");
+
             return Path.Combine(basePath, "Lib", "site-packages");
         }
 
         public string GetSitePackagesPathFromPythonHome()
         {
+
+
             var pythonHome = Environment.GetEnvironmentVariable("PYTHONHOME", EnvironmentVariableTarget.Process);
 
             if (string.IsNullOrEmpty(pythonHome))
                 return string.Empty;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return GetSitePackagesPath(pythonHome);
 
             var isVirtualEnv = pythonHome.EndsWith(EnvironmentConsts.VirtualEnvironment, StringComparison.OrdinalIgnoreCase);
 
@@ -110,7 +126,7 @@ namespace LangSharp.Core.Services
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) switch
             {
                 true => Path.Combine(pythonHome, "Scripts", "python.exe"),
-                false when RuntimeInformation.IsOSPlatform(OSPlatform.Linux) => Path.Combine(pythonHome, "bin", "python"),
+                false when RuntimeInformation.IsOSPlatform(OSPlatform.Linux) => Path.Combine(pythonHome, "bin", "python3.11"),
                 _ => throw new PlatformNotSupportedException("Unsupported operating system.")
             };
         }
@@ -120,7 +136,7 @@ namespace LangSharp.Core.Services
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) switch
             {
                 true => Path.Combine(pythonHome, "python.exe"),
-                false when RuntimeInformation.IsOSPlatform(OSPlatform.Linux) => Path.Combine(pythonHome, "bin", "python"),
+                false when RuntimeInformation.IsOSPlatform(OSPlatform.Linux) => Path.Combine(pythonHome, "bin", "python3.11"),
                 _ => throw new PlatformNotSupportedException("Unsupported operating system.")
             };
         }

--- a/src/LangSharp/Core/Services/PathService.cs
+++ b/src/LangSharp/Core/Services/PathService.cs
@@ -66,7 +66,7 @@ namespace LangSharp.Core.Services
             return Path.Combine(basePath, "Lib", "site-packages");
         }
 
-        public string GetSitePackagesPathFromPythonHome()
+        public string GetSitePackagesPath()
         {
             var pythonHome = Environment.GetEnvironmentVariable("PYTHONHOME", EnvironmentVariableTarget.Process);
 

--- a/src/LangSharp/Core/Services/PathService.cs
+++ b/src/LangSharp/Core/Services/PathService.cs
@@ -50,18 +50,25 @@ namespace LangSharp.Core.Services
             return pythonPath;
         }
 
+        public string GetPythonVenvPath()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return Path.Combine(Path.DirectorySeparatorChar.ToString(), "usr");
+
+            string nugetPath = GetNuggetPath();
+
+            var pythonPath = Path.Combine(nugetPath, "python", EnvironmentConsts.PythonVersion, EnvironmentConsts.VirtualEnvironment);
+
+            return pythonPath;
+        }
+
         public string GetPythonPathExecutable()
         {
-            var pythonHome = Environment.GetEnvironmentVariable("PYTHONHOME", EnvironmentVariableTarget.Process);
+            var isVenv = Environment.GetEnvironmentVariable("LANGSHARP_IS_VENV", EnvironmentVariableTarget.Process);
 
-            if (string.IsNullOrEmpty(pythonHome))
-                return string.Empty;
-
-            var isVirtualEnv = pythonHome.EndsWith(EnvironmentConsts.VirtualEnvironment, StringComparison.OrdinalIgnoreCase);
-
-            return isVirtualEnv
-                ? GetPythonPathExecutableForVenv(pythonHome)
-                : GetPythonPathExecutableForStandardInstallation(pythonHome);
+            return !string.IsNullOrEmpty(isVenv) && bool.Parse(isVenv)
+                ? GetPythonPathExecutableForVenv(GetPythonVenvPath())
+                : GetPythonPathExecutableForStandardInstallation(GetPythonPath());
         }
 
         public string GetScriptsPath(string scriptName)
@@ -90,8 +97,6 @@ namespace LangSharp.Core.Services
 
         public string GetSitePackagesPathFromPythonHome()
         {
-
-
             var pythonHome = Environment.GetEnvironmentVariable("PYTHONHOME", EnvironmentVariableTarget.Process);
 
             if (string.IsNullOrEmpty(pythonHome))
@@ -100,10 +105,10 @@ namespace LangSharp.Core.Services
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 return GetSitePackagesPath(pythonHome);
 
-            var isVirtualEnv = pythonHome.EndsWith(EnvironmentConsts.VirtualEnvironment, StringComparison.OrdinalIgnoreCase);
+            var isVirtualEnv = Environment.GetEnvironmentVariable("LANGSHARP_IS_VENV", EnvironmentVariableTarget.Process);
 
-            return isVirtualEnv
-                ? Path.Combine(pythonHome, "Lib", "site-packages")
+            return  !string.IsNullOrEmpty(isVirtualEnv) && bool.Parse(isVirtualEnv)
+                ? Path.Combine(GetPythonVenvPath(), "Lib", "site-packages")
                 : Path.Combine(pythonHome, "Lib");
         }
 

--- a/src/LangSharp/Core/Services/PythonService.cs
+++ b/src/LangSharp/Core/Services/PythonService.cs
@@ -127,12 +127,29 @@ namespace LangSharp.Core.Services
         public void CreateVirtualEnv()
         {
             string venvPath = _pathService.GetVenvPath();
+            string pythonExecutable = _pathService.GetPythonPathExecutable();
 
-            using (_pythonRuntime.AcquireGIL())
+            var startInfo = new System.Diagnostics.ProcessStartInfo
             {
-                dynamic subprocess = _pythonRuntime.Import("subprocess");
-                subprocess.check_call(new[] { "python", "-m", "venv", venvPath });
-            }
+                FileName = pythonExecutable,
+                Arguments = $"-m venv \"{venvPath}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = System.Diagnostics.Process.Start(startInfo);
+
+            if (process == null)
+                throw new InvalidOperationException("Could not start the process to create the virtual environment.");
+
+            string output = process.StandardOutput.ReadToEnd();
+            string error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+                throw new Exception($"Error creating virtual environment: {error}\n{output}");
         }
 
         public bool IsVirtualEnvCreated()

--- a/src/LangSharp/Core/Services/PythonService.cs
+++ b/src/LangSharp/Core/Services/PythonService.cs
@@ -50,7 +50,7 @@ namespace LangSharp.Core.Services
         public string ExecuteScript(AbstractScript scriptModel)
         {
             var pythonScriptPath = GetScriptPath(scriptModel.Name);
-            var pythonPackgesPath = _pathService.GetSitePackagesPathFromPythonHome();
+            var pythonPackgesPath = _pathService.GetSitePackagesPath();
 
             using (_pythonRuntime.AcquireGIL())
             {
@@ -127,51 +127,16 @@ namespace LangSharp.Core.Services
 
         public void CreateVirtualEnv()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                CreateVirtualEnvLinux();
-                return;
-            }
-
             string venvPath = _pathService.GetVenvPath();
             string pythonExecutable = _pathService.GetPythonPathExecutable();
 
 
             using (_pythonRuntime.AcquireGIL())
             {
-
                 dynamic subprocess = _pythonRuntime.Import("subprocess");
                 subprocess.check_call(new[] { pythonExecutable, "-m", "venv", venvPath});
             }
 
-        }
-
-        private void CreateVirtualEnvLinux() 
-        {
-            string venvPath = _pathService.GetVenvPath();
-            string pythonExecutable = _pathService.GetPythonPathExecutable();
-
-            var startInfo = new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = pythonExecutable,
-                Arguments = $"-m venv \"{venvPath}\"",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            using var process = System.Diagnostics.Process.Start(startInfo);
-
-            if (process == null)
-                throw new InvalidOperationException("Could not start the process to create the virtual environment.");
-
-            string output = process.StandardOutput.ReadToEnd();
-            string error = process.StandardError.ReadToEnd();
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
-                throw new Exception($"Error creating virtual environment: {error}\n{output}");
         }
 
         public bool IsVirtualEnvCreated()

--- a/src/LangSharp/Core/Services/PythonService.cs
+++ b/src/LangSharp/Core/Services/PythonService.cs
@@ -2,6 +2,7 @@
 using LangSharp.Core.Interfaces.Infrastructure;
 using LangSharp.Core.Interfaces.Services;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 
 namespace LangSharp.Core.Services
 {
@@ -125,6 +126,24 @@ namespace LangSharp.Core.Services
         }
 
         public void CreateVirtualEnv()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                CreateVirtualEnvLinux();
+                return;
+            }
+
+            string venvPath = _pathService.GetVenvPath();
+
+            using (_pythonRuntime.AcquireGIL())
+            {
+                dynamic subprocess = _pythonRuntime.Import("subprocess");
+                subprocess.check_call(new[] { "python", "-m", "venv", venvPath });
+            }
+
+        }
+
+        private void CreateVirtualEnvLinux() 
         {
             string venvPath = _pathService.GetVenvPath();
             string pythonExecutable = _pathService.GetPythonPathExecutable();

--- a/src/LangSharp/Core/Services/PythonService.cs
+++ b/src/LangSharp/Core/Services/PythonService.cs
@@ -134,11 +134,14 @@ namespace LangSharp.Core.Services
             }
 
             string venvPath = _pathService.GetVenvPath();
+            string pythonExecutable = _pathService.GetPythonPathExecutable();
+
 
             using (_pythonRuntime.AcquireGIL())
             {
+
                 dynamic subprocess = _pythonRuntime.Import("subprocess");
-                subprocess.check_call(new[] { "python", "-m", "venv", venvPath });
+                subprocess.check_call(new[] { pythonExecutable, "-m", "venv", venvPath});
             }
 
         }
@@ -178,10 +181,10 @@ namespace LangSharp.Core.Services
 
         public void ActivateVirtualEnv()
         {
-            var venvPath = _pathService.GetVenvPath();
+            var venvPath = _pathService.GetVenvPath(); 
             var sitePackagesPath = _pathService.GetSitePackagesPath(venvPath);
 
-            _env.ConfigurePythonEnvironment(venvPath, sitePackagesPath);
+            _env.ConfigurePythonVirtualEnvironment(sitePackagesPath, true);
         }
 
         public string GetScriptPath(string scriptName)

--- a/src/LangSharp/LangSharp.csproj
+++ b/src/LangSharp/LangSharp.csproj
@@ -15,7 +15,7 @@
 		<PackageTags>python;dotnet;sdk;integration</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<Version>1.0.18</Version>
+		<Version>1.0.19</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/LangSharp/LangSharp.csproj
+++ b/src/LangSharp/LangSharp.csproj
@@ -15,7 +15,7 @@
 		<PackageTags>python;dotnet;sdk;integration</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<Version>1.0.19</Version>
+		<Version>1.0.20</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/LangSharp/Registrations/ServiceRegistration.cs
+++ b/src/LangSharp/Registrations/ServiceRegistration.cs
@@ -5,6 +5,7 @@ using LangSharp.Core.Infrastructure;
 using LangSharp.Core.Interfaces.Configurations;
 using LangSharp.Core.Interfaces.Handlers;
 using LangSharp.Core.Interfaces.Infrastructure;
+using LangSharp.Core.Interfaces.Providers;
 using LangSharp.Core.Interfaces.Services;
 using LangSharp.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,11 +31,11 @@ namespace LangSharp.Registrations
             services.TryAddScoped<IConfigurationService, ConfigurationService>();
 
             //add services
-            services.TryAddScoped<ILangSharpService, LangSharpService>();
-            services.TryAddScoped<IPythonService, PythonService>();
             services.TryAddScoped<IEnvironmentService, EnvironmentService>();
-            services.TryAddScoped<IPathService, PathService>();
+            services.TryAddScoped<ILangSharpService, LangSharpService>();
             services.TryAddScoped<IFileSystemService, FileSystemService>();
+            services.TryAddScoped<IFileSystemService, FileSystemService>();
+            services.TryAddScoped<IPythonService, PythonService>();
 
             //Add Infra
             services.TryAddScoped<IPythonRuntime, PythonRuntime>();
@@ -42,13 +43,17 @@ namespace LangSharp.Registrations
             //Add SDK Config
             services.TryAddSingleton(configuration);
 
+            //Add Path Service For Current Environment (windows/linux)
+            services.TryAddSingleton(PathServiceFactory.CreateForCurrentEnvironment());
+
             // Build a temporary service provider to resolve IPythonService
             var serviceProvider = services.BuildServiceProvider();
             IPythonService pythonService = serviceProvider.GetRequiredService<IPythonService>();
 
             // Add AI Provider
-            var aiProvider = CloudAIProviderFactory.CreateProvider(configuration.AIProvider, pythonService);
+            ICloudAIProvider aiProvider = CloudAIProviderFactory.CreateProvider(configuration.AIProvider, pythonService);
             services.TryAddSingleton(aiProvider);
+
         }
     }
 }


### PR DESCRIPTION
Melhora a documentação no `README.md` com a atualização da instalação do Python para "Python 3.11.x" e a inclusão do pacote `python3-venv` para contêineres Linux.

No `PathService.cs`, ajusta funções para retornar caminhos corretos para pacotes NuGet e Python, considerando o sistema operacional. Atualiza a nomenclatura de diretórios e aprimora o tratamento de ambientes virtuais.

No `PythonService.cs`, modifica a criação de ambientes virtuais para usar o executável Python correto e adiciona captura de saída e erro para melhor tratamento de falhas.