### PR TITLE
Adiciona suporte a scripts Python incorporados

### DIFF
--- a/src/LangSharp/Core/Interfaces/Services/IFileSystemService.cs
+++ b/src/LangSharp/Core/Interfaces/Services/IFileSystemService.cs
@@ -4,5 +4,6 @@
     {
         bool IsValidDirectory(string? path);
         bool IsFileExist(string? path);
+        string? WriteEmbeddedPythonScriptToProjectRoot(string scriptName);
     }
 }

--- a/src/LangSharp/Core/Interfaces/Services/IPathService.cs
+++ b/src/LangSharp/Core/Interfaces/Services/IPathService.cs
@@ -8,6 +8,7 @@
         string GetPythonPathExecutable();
         string GetSitePackagesPath(string basePath);
         string GetVenvPath();
+        string GetEmbeddedScriptsPath(string scriptName);
         string GetScriptsPath(string scriptName);
         string GetScriptsPathByPackageDir(string scriptName);
         string GetSitePackagesPath();

--- a/src/LangSharp/Core/Services/FileSystemService.cs
+++ b/src/LangSharp/Core/Services/FileSystemService.cs
@@ -1,4 +1,5 @@
 ﻿using LangSharp.Core.Interfaces.Services;
+using LangSharp.Utils;
 
 namespace LangSharp.Core.Services
 {
@@ -12,6 +13,25 @@ namespace LangSharp.Core.Services
         public bool IsFileExist(string? path)
         {
             return !string.IsNullOrWhiteSpace(path) && File.Exists(path);
+        }
+
+        public string? WriteEmbeddedPythonScriptToProjectRoot(string scriptName)
+        {
+            // Reads the embedded Python script from the specified resource name
+            var embeddedScript = ResourceHelper.ReadEmbeddedPythonScript(scriptName);
+
+            if (string.IsNullOrWhiteSpace(embeddedScript))
+                return null;
+
+            // Uses the project root (bin output directory) as the destination
+            var projectRoot = AppContext.BaseDirectory;
+            var scriptPath = Path.Combine(projectRoot, scriptName);
+
+            // Writes the embedded script content to the file in the project root
+            File.WriteAllText(scriptPath, embeddedScript);
+
+            // Returns the path to the created script file, or null if failed
+            return scriptPath;
         }
     }
 }

--- a/src/LangSharp/Core/Services/PathLinuxService.cs
+++ b/src/LangSharp/Core/Services/PathLinuxService.cs
@@ -83,5 +83,10 @@ namespace LangSharp.Core.Services
         {
             return Path.GetDirectoryName(path) ?? string.Empty;
         }
+
+        public string GetEmbeddedScriptsPath(string scriptName)
+        {
+            return Path.Combine(AppContext.BaseDirectory, scriptName);
+        }
     }
 }

--- a/src/LangSharp/Core/Services/PathService.cs
+++ b/src/LangSharp/Core/Services/PathService.cs
@@ -104,5 +104,9 @@ namespace LangSharp.Core.Services
             return Path.Combine(pythonHome, "python.exe");
         }
 
+        public string GetEmbeddedScriptsPath(string scriptName)
+        {
+            return Path.Combine(AppContext.BaseDirectory, scriptName);
+        }
     }
 }

--- a/src/LangSharp/Core/Services/PythonService.cs
+++ b/src/LangSharp/Core/Services/PythonService.cs
@@ -14,7 +14,7 @@ namespace LangSharp.Core.Services
     {
         private readonly IPythonRuntime _pythonRuntime;
         private readonly IEnvironmentService _env;
-        private readonly IPathService  _pathService;
+        private readonly IPathService _pathService;
         private readonly IFileSystemService _fileSystemService;
 
         public PythonService(IPythonRuntime pythonRuntime, IEnvironmentService env, IPathService pathService, IFileSystemService fileSystemService)
@@ -50,8 +50,10 @@ namespace LangSharp.Core.Services
         public string ExecuteScript(AbstractScript scriptModel)
         {
             var pythonScriptPath = GetScriptPath(scriptModel.Name);
+
             var pythonPackgesPath = _pathService.GetSitePackagesPath();
 
+            Console.ReadLine();
             using (_pythonRuntime.AcquireGIL())
             {
                 dynamic sys = _pythonRuntime.Import("sys");
@@ -134,7 +136,7 @@ namespace LangSharp.Core.Services
             using (_pythonRuntime.AcquireGIL())
             {
                 dynamic subprocess = _pythonRuntime.Import("subprocess");
-                subprocess.check_call(new[] { pythonExecutable, "-m", "venv", venvPath});
+                subprocess.check_call(new[] { pythonExecutable, "-m", "venv", venvPath });
             }
 
         }
@@ -146,7 +148,7 @@ namespace LangSharp.Core.Services
 
         public void ActivateVirtualEnv()
         {
-            var venvPath = _pathService.GetVenvPath(); 
+            var venvPath = _pathService.GetVenvPath();
             var sitePackagesPath = _pathService.GetSitePackagesPath(venvPath);
 
             _env.ConfigurePythonVirtualEnvironment(sitePackagesPath, true);
@@ -161,10 +163,20 @@ namespace LangSharp.Core.Services
 
             scriptPath = _pathService.GetScriptsPathByPackageDir(scriptName);
 
-            if (!_fileSystemService.IsFileExist(scriptPath))
-                throw new FileNotFoundException($"Script '{scriptName}' not found in any of the verified paths.");
+            if (_fileSystemService.IsFileExist(scriptPath))
+                return scriptPath;
 
-            return scriptPath;
+            scriptPath = _pathService.GetEmbeddedScriptsPath(scriptName);
+
+            if (_fileSystemService.IsFileExist(scriptPath))
+                return scriptPath;
+
+            scriptPath = _fileSystemService.WriteEmbeddedPythonScriptToProjectRoot(scriptName);
+
+            if (!string.IsNullOrEmpty(scriptPath) && _fileSystemService.IsFileExist(scriptPath))
+                return scriptPath;
+
+            throw new FileNotFoundException($"Script '{scriptName}' not found in any of the verified paths.");
         }
     }
 }

--- a/src/LangSharp/LangSharp.csproj
+++ b/src/LangSharp/LangSharp.csproj
@@ -15,7 +15,7 @@
 		<PackageTags>python;dotnet;sdk;integration</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<Version>1.0.22</Version>
+		<Version>1.0.23</Version>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -24,6 +24,10 @@
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>
+	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Include="Scripts\**\*" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/LangSharp/Utils/ResourceHelper.cs
+++ b/src/LangSharp/Utils/ResourceHelper.cs
@@ -1,0 +1,25 @@
+﻿using System.Reflection;
+
+namespace LangSharp.Utils
+{
+    public static class ResourceHelper
+    {
+        private const string LangSharpEmbeddedName = "LangSharp.Scripts";
+        public static string ReadEmbeddedPythonScript(string scriptName)
+        {
+            var resourceName = $"{LangSharpEmbeddedName}.{scriptName}";
+
+
+            var assembly = Assembly.GetExecutingAssembly();
+
+            foreach (var name in assembly.GetManifestResourceNames())
+            {
+                Console.WriteLine(name);
+            }
+
+            using var stream = assembly.GetManifestResourceStream(resourceName);
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+    }
+}


### PR DESCRIPTION
Implementa métodos para manipulação de scripts Python incorporados no sistema de arquivos, incluindo `WriteEmbeddedPythonScriptToProjectRoot` e `GetEmbeddedScriptsPath`. Atualiza `PythonService` para utilizar esses métodos.

Atualiza `LangSharp.csproj` para incluir novos recursos incorporados e altera a versão do pacote para `1.0.23`.

Cria a classe `ResourceHelper` para facilitar a leitura de scripts Python incorporados usando reflexão.