### PR TITLE
Atualiza PythonService e versão do pacote para 1.0.24

### DIFF
--- a/src/LangSharp/Core/Services/PythonService.cs
+++ b/src/LangSharp/Core/Services/PythonService.cs
@@ -50,10 +50,8 @@ namespace LangSharp.Core.Services
         public string ExecuteScript(AbstractScript scriptModel)
         {
             var pythonScriptPath = GetScriptPath(scriptModel.Name);
-
             var pythonPackgesPath = _pathService.GetSitePackagesPath();
 
-            Console.ReadLine();
             using (_pythonRuntime.AcquireGIL())
             {
                 dynamic sys = _pythonRuntime.Import("sys");

--- a/src/LangSharp/LangSharp.csproj
+++ b/src/LangSharp/LangSharp.csproj
@@ -15,7 +15,7 @@
 		<PackageTags>python;dotnet;sdk;integration</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<Version>1.0.23</Version>
+		<Version>1.0.24</Version>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Removidas linhas desnecessárias no `PythonService.cs` para simplificar a execução do script, eliminando a necessidade de interação do usuário.

A versão do pacote foi atualizada de `1.0.23` para `1.0.24`, refletindo melhorias e possíveis correções de bugs.