### PR TITLE
Adicionar constante LangChainGoogleVertexAI e teste

### DIFF
--- a/src/LangSharp/LangSharp.csproj
+++ b/src/LangSharp/LangSharp.csproj
@@ -15,7 +15,7 @@
 		<PackageTags>python;dotnet;sdk;integration</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<Version>1.0.28</Version>
+		<Version>1.0.29</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/LangSharp/Utils/PythonPackage.cs
+++ b/src/LangSharp/Utils/PythonPackage.cs
@@ -6,5 +6,6 @@
         public const string LangChainCommunity = "langchain-community";
         public const string LangChainOpenai = "langchain-openai";
         public const string LangChainGoogleGenaiAI = "langchain-google-genai";
+        public const string LangChainGoogleVertexAI = "langchain-google-vertexai";
     }
 }

--- a/tests/LangSharp.UnitTests/Utils/PythonPackageTests.cs
+++ b/tests/LangSharp.UnitTests/Utils/PythonPackageTests.cs
@@ -27,5 +27,11 @@ namespace LangSharp.UnitTests.Utils
         {
             Assert.Equal("langchain-google-genai", PythonPackage.LangChainGoogleGenaiAI);
         }
+
+        [Fact]
+        public void LangChainGoogleVertexAI_ShouldBeCorrect()
+        {
+            Assert.Equal("langchain-google-vertexai", PythonPackage.LangChainGoogleVertexAI);
+        }
     }
 }


### PR DESCRIPTION
Foi adicionada uma nova constante `LangChainGoogleVertexAI` com o valor `"langchain-google-vertexai"` na classe `PythonPackage`.

Além disso, foi implementado um novo teste unitário `LangChainGoogleVertexAI_ShouldBeCorrect` na classe de testes `PythonPackageTests` para validar o valor da nova constante.