### PR TITLE
Adiciona suporte ao LangChainGoogleVertexAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ LangSharp SDK is a .NET 8 library that leverages Python.NET to communicate with 
 - [Introduction](#introduction)
 - [Features](#features)
 - [Getting Started](#getting-started)
-  - [Requisites] (#requisites)
   - [Installation](#installation)
   - [Configuration](#configuration)
 - [Usage](#usage)
@@ -24,10 +23,6 @@ LangSharp SDK is designed to bridge the gap between .NET applications and Python
 - **Chain Requests**: Create chains through Python to make requests to AI providers.
 
 ## Getting Started
-
-### Requisites
-
-Python.NET requires Python 3.11.7 to be installed in the system.
 
 
 ### Installation
@@ -101,7 +96,7 @@ To run the LangSharp SDK in a Docker container, ensure Python and required depen
 
 ### Linux
 
-Install Python 3.11.x:
+Install Python 3.11.7:
 
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base

--- a/src/LangSharp/Core/Providers/LangChainProvider.cs
+++ b/src/LangSharp/Core/Providers/LangChainProvider.cs
@@ -43,6 +43,7 @@ namespace LangSharp.Core.Providers
                 _pythonService.InstallPackage(PythonPackage.LangChainCommunity);
                 _pythonService.InstallPackage(PythonPackage.PythonDotEnv);
                 _pythonService.InstallPackage(PythonPackage.LangChainGoogleGenaiAI);
+                _pythonService.InstallPackage(PythonPackage.LangChainGoogleVertexAI);
 
                 return true;
             }

--- a/src/LangSharp/LangSharp.csproj
+++ b/src/LangSharp/LangSharp.csproj
@@ -15,7 +15,7 @@
 		<PackageTags>python;dotnet;sdk;integration</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<Version>1.0.29</Version>
+		<Version>1.0.30</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/LangSharp.UnitTests/Core/Providers/LangChainProviderTests.cs
+++ b/tests/LangSharp.UnitTests/Core/Providers/LangChainProviderTests.cs
@@ -78,6 +78,8 @@ namespace LangSharp.UnitTests.Core.Providers
             pythonServiceMock.Verify(p => p.InstallPackage("langchain-openai"), Times.Once);
             pythonServiceMock.Verify(p => p.InstallPackage("langchain-community"), Times.Once);
             pythonServiceMock.Verify(p => p.InstallPackage("python-dotenv"), Times.Once);
+            pythonServiceMock.Verify(p => p.InstallPackage("langchain-google-genai"), Times.Once);
+            pythonServiceMock.Verify(p => p.InstallPackage("langchain-google-vertexai"), Times.Once); 
         }
 
         [Fact]


### PR DESCRIPTION
Inclui a instalação do pacote `LangChainGoogleVertexAI` no `LangChainProvider.cs`. Atualiza a versão do projeto para `1.0.30` no `LangSharp.csproj`. Adiciona verificações nos testes para os pacotes `langchain-google-genai` e `langchain-google-vertexai`.